### PR TITLE
Add startup check for required environment variables

### DIFF
--- a/src/lib/strava.ts
+++ b/src/lib/strava.ts
@@ -1,12 +1,28 @@
 const STRAVA_API_BASE = "https://www.strava.com/api/v3";
 const STRAVA_AUTH_BASE = "https://www.strava.com/oauth";
 
-export const STRAVA_CLIENT_ID = process.env.STRAVA_CLIENT_ID!;
-export const STRAVA_CLIENT_SECRET = process.env.STRAVA_CLIENT_SECRET!;
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+      `Add it to .env.local (see .env.example for reference).`
+    );
+  }
+  return value;
+}
+
+export function getClientId() {
+  return requireEnv("STRAVA_CLIENT_ID");
+}
+
+export function getClientSecret() {
+  return requireEnv("STRAVA_CLIENT_SECRET");
+}
 
 export function getAuthUrl(state: string, origin: string) {
   const params = new URLSearchParams({
-    client_id: STRAVA_CLIENT_ID,
+    client_id: getClientId(),
     redirect_uri: `${origin}/api/auth/callback`,
     response_type: "code",
     scope: "read,activity:read_all",
@@ -20,8 +36,8 @@ export async function exchangeToken(code: string): Promise<StravaTokens> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      client_id: STRAVA_CLIENT_ID,
-      client_secret: STRAVA_CLIENT_SECRET,
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
       code,
       grant_type: "authorization_code",
     }),
@@ -35,8 +51,8 @@ export async function refreshAccessToken(refreshToken: string): Promise<StravaTo
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      client_id: STRAVA_CLIENT_ID,
-      client_secret: STRAVA_CLIENT_SECRET,
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
       grant_type: "refresh_token",
       refresh_token: refreshToken,
     }),


### PR DESCRIPTION
## Summary
- Add `requireEnv` helper in `src/lib/strava.ts` that throws a descriptive error when env vars are missing
- Replace non-null assertions with lazy `getClientId()` / `getClientSecret()` function calls
- Clear error message references `.env.example` for guidance

Closes #9

## Test plan
- [ ] Remove `STRAVA_CLIENT_ID` from `.env.local`, hit `/api/auth/strava` — confirm clear error
- [ ] Restore variable, confirm app works normally
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)