### PR TITLE
Centralize chart data sorting in dashboard page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type StravaActivity } from "@/lib/strava";
 import SummaryCards from "@/components/SummaryCards";
 import RecentRides from "@/components/RecentRides";
@@ -13,6 +13,14 @@ export default function Dashboard() {
   const [activities, setActivities] = useState<StravaActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const sortedRecent = useMemo(
+    () =>
+      [...activities]
+        .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local))
+        .slice(-30),
+    [activities]
+  );
 
   useEffect(() => {
     fetch("/api/activities")
@@ -71,10 +79,10 @@ export default function Dashboard() {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <DistanceChart activities={activities} />
-          <SpeedChart activities={activities} />
+          <SpeedChart activities={sortedRecent} />
         </div>
 
-        <ElevationChart activities={activities} />
+        <ElevationChart activities={sortedRecent} />
 
         <RecentRides activities={activities} />
       </div>

--- a/src/components/ElevationChart.tsx
+++ b/src/components/ElevationChart.tsx
@@ -18,16 +18,13 @@ interface Props {
 
 export default function ElevationChart({ activities }: Props) {
   const data = useMemo(() => {
-    return [...activities]
-      .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local))
-      .slice(-30)
-      .map((a) => ({
-        date: new Date(a.start_date_local).toLocaleDateString("en-GB", {
-          day: "numeric",
-          month: "short",
-        }),
-        elevation: Math.round(a.total_elevation_gain),
-      }));
+    return activities.map((a) => ({
+      date: new Date(a.start_date_local).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+      }),
+      elevation: Math.round(a.total_elevation_gain),
+    }));
   }, [activities]);
 
   return (

--- a/src/components/SpeedChart.tsx
+++ b/src/components/SpeedChart.tsx
@@ -18,16 +18,13 @@ interface Props {
 
 export default function SpeedChart({ activities }: Props) {
   const data = useMemo(() => {
-    return [...activities]
-      .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local))
-      .slice(-30)
-      .map((a) => ({
-        date: new Date(a.start_date_local).toLocaleDateString("en-GB", {
-          day: "numeric",
-          month: "short",
-        }),
-        speed: Math.round(a.average_speed * 3.6 * 10) / 10,
-      }));
+    return activities.map((a) => ({
+      date: new Date(a.start_date_local).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+      }),
+      speed: Math.round(a.average_speed * 3.6 * 10) / 10,
+    }));
   }, [activities]);
 
   return (


### PR DESCRIPTION
## Summary
- Add `useMemo` in dashboard to compute sorted+sliced recent activities once
- Pass pre-processed data to `SpeedChart` and `ElevationChart`
- Remove redundant sort+slice from both chart components
- `DistanceChart` unchanged (needs full dataset for weekly aggregation)

Closes #11

## Test plan
- [ ] All three charts render identically before and after
- [ ] X-axis ordering preserved (chronological, oldest to newest)
- [ ] Empty state still works
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)