### PR TITLE
Add explicit type annotations to chart tooltip formatters

### DIFF
--- a/src/components/DistanceChart.tsx
+++ b/src/components/DistanceChart.tsx
@@ -56,7 +56,7 @@ export default function DistanceChart({ activities }: Props) {
                 border: "1px solid rgba(128,128,128,0.2)",
                 borderRadius: "8px",
               }}
-              formatter={(value) => [`${value} km`, "Distance"]}
+              formatter={(value: number | undefined) => [`${value} km`, "Distance"]}
             />
             <Bar dataKey="km" fill="#FC4C02" radius={[4, 4, 0, 0]} />
           </BarChart>

--- a/src/components/ElevationChart.tsx
+++ b/src/components/ElevationChart.tsx
@@ -47,7 +47,7 @@ export default function ElevationChart({ activities }: Props) {
                 border: "1px solid rgba(128,128,128,0.2)",
                 borderRadius: "8px",
               }}
-              formatter={(value) => [`${value} m`, "Elevation"]}
+              formatter={(value: number | undefined) => [`${value} m`, "Elevation"]}
             />
             <Area
               type="monotone"

--- a/src/components/SpeedChart.tsx
+++ b/src/components/SpeedChart.tsx
@@ -47,7 +47,7 @@ export default function SpeedChart({ activities }: Props) {
                 border: "1px solid rgba(128,128,128,0.2)",
                 borderRadius: "8px",
               }}
-              formatter={(value) => [`${value} km/h`, "Avg Speed"]}
+              formatter={(value: number | undefined) => [`${value} km/h`, "Avg Speed"]}
             />
             <Line
               type="monotone"


### PR DESCRIPTION
## Summary
- Add `number | undefined` type annotation to tooltip `formatter` callback in all three chart components
- Fixes implicit `any` under strict TypeScript settings
- Type-annotation-only change, zero runtime impact

Closes #12

## Test plan
- [ ] Tooltips display correctly on hover in all three charts
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)