### PR TITLE
Add year-over-year monthly comparison chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,12 @@ src/
     SpeedChart.tsx         # Average speed trend line chart
     ElevationChart.tsx     # Elevation gain per ride area chart
     ThemeProvider.tsx      # Client wrapper for next-themes provider
+    YearComparisonChart.tsx # Year-over-year monthly grouped bar chart with metric toggle
     ThemeToggle.tsx        # Dark/light theme toggle with sun/moon icons
     RideHeatmap.tsx       # Leaflet map with all ride routes as polylines
   lib/
     strava.ts             # Strava API client with Zod-validated responses
+    year-comparison.ts    # Year-over-year data aggregation, metric formatting, summary text
     tokens.ts             # Cookie-based token storage with auto-refresh and size checks
     format.ts             # Formatting helpers (distance, duration, speed, elevation, date)
     polyline.ts           # Google encoded polyline decoder

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import DistanceChart from "@/components/DistanceChart";
 import SpeedChart from "@/components/SpeedChart";
 import ElevationChart from "@/components/ElevationChart";
 import PersonalRecords from "@/components/PersonalRecords";
+import YearComparisonChart from "@/components/YearComparisonChart";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 const RideHeatmap = dynamic(() => import("@/components/RideHeatmap"), {
@@ -92,6 +93,8 @@ export default function Dashboard() {
         <SummaryCards activities={activities} />
 
         <PersonalRecords activities={activities} />
+
+        <YearComparisonChart activities={activities} />
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <DistanceChart activities={activities} />

--- a/src/components/YearComparisonChart.tsx
+++ b/src/components/YearComparisonChart.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { type StravaActivity } from "@/lib/strava";
+import {
+  aggregateByYearMonth,
+  formatMetricValue,
+  formatSummaryText,
+  type YearComparisonMetric,
+} from "@/lib/year-comparison";
+
+interface Props {
+  activities: StravaActivity[];
+}
+
+const METRICS: { key: YearComparisonMetric; label: string }[] = [
+  { key: "distance", label: "Distance" },
+  { key: "elevation", label: "Elevation" },
+  { key: "rides", label: "Rides" },
+  { key: "time", label: "Time" },
+];
+
+const YAXIS_UNITS: Record<YearComparisonMetric, string> = {
+  distance: " km",
+  elevation: " m",
+  rides: "",
+  time: " hrs",
+};
+
+export default function YearComparisonChart({ activities }: Props) {
+  const [metric, setMetric] = useState<YearComparisonMetric>("distance");
+
+  const result = useMemo(
+    () => aggregateByYearMonth(activities, metric),
+    [activities, metric],
+  );
+
+  const summary = useMemo(
+    () => formatSummaryText(result, metric),
+    [result, metric],
+  );
+
+  const hasData = activities.length > 0;
+
+  return (
+    <div className="bg-foreground/5 rounded-xl p-6">
+      <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
+        <h2 className="text-xl font-semibold text-foreground">
+          Year-over-Year Comparison
+        </h2>
+        <div className="flex gap-1 bg-foreground/[0.08] rounded-lg p-[3px]">
+          {METRICS.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setMetric(key)}
+              className={`text-sm font-medium px-3.5 py-1.5 rounded-md transition-colors whitespace-nowrap ${
+                metric === key
+                  ? "bg-[#FC4C02] text-white"
+                  : "bg-transparent text-foreground/50 hover:text-foreground hover:bg-foreground/[0.08]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!hasData ? (
+        <p className="text-foreground/40 text-center py-8">No data</p>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={340}>
+            <BarChart data={result.data}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="currentColor"
+                opacity={0.1}
+              />
+              <XAxis
+                dataKey="month"
+                tick={{ fontSize: 12 }}
+                stroke="currentColor"
+                opacity={0.5}
+              />
+              <YAxis
+                tick={{ fontSize: 12 }}
+                stroke="currentColor"
+                opacity={0.5}
+                unit={YAXIS_UNITS[metric]}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "var(--background)",
+                  border: "1px solid rgba(128,128,128,0.2)",
+                  borderRadius: "8px",
+                }}
+                formatter={
+                  ((value: number, name: string) => [
+                    formatMetricValue(value, metric),
+                    name,
+                  ]) as never
+                }
+              />
+              <Bar
+                dataKey="current"
+                name={`${result.currentYear}`}
+                fill="#FC4C02"
+                radius={[4, 4, 0, 0]}
+              />
+              <Bar
+                dataKey="previous"
+                name={`${result.previousYear}`}
+                fill="rgba(128,128,128,0.3)"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+
+          <div className="flex items-center gap-5 mt-4 pt-4 border-t border-foreground/10">
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded bg-[#FC4C02]" />
+              <span className="text-sm text-foreground/50">
+                {result.currentYear}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span
+                className="w-3 h-3 rounded"
+                style={{ backgroundColor: "rgba(128,128,128,0.3)" }}
+              />
+              <span className="text-sm text-foreground/50">
+                {result.previousYear}
+              </span>
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm text-foreground/50">
+            {summary.text}
+            <span className="text-[#FC4C02] font-semibold">
+              {summary.highlight}
+            </span>
+            {summary.suffix}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/year-comparison.test.ts
+++ b/src/lib/__tests__/year-comparison.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect } from "vitest";
+import { type StravaActivity } from "@/lib/strava";
+import {
+  aggregateByYearMonth,
+  formatMetricValue,
+  formatSummaryText,
+} from "@/lib/year-comparison";
+
+function makeActivity(overrides: Partial<StravaActivity> = {}): StravaActivity {
+  return {
+    id: 1,
+    name: "Ride",
+    type: "Ride",
+    sport_type: "Ride",
+    distance: 25000,
+    moving_time: 3600,
+    elapsed_time: 3600,
+    total_elevation_gain: 200,
+    start_date: "2026-01-15T10:00:00Z",
+    start_date_local: "2026-01-15T10:00:00Z",
+    average_speed: 6.94,
+    max_speed: 10.0,
+    ...overrides,
+  };
+}
+
+const NOW = new Date("2026-03-15");
+
+describe("aggregateByYearMonth", () => {
+  it("returns 12 zeroed months with correct years when given no activities", () => {
+    const result = aggregateByYearMonth([], "distance", NOW);
+
+    expect(result.data).toHaveLength(12);
+    expect(result.data.every((d) => d.current === 0 && d.previous === 0)).toBe(
+      true
+    );
+    expect(result.currentYear).toBe(2026);
+    expect(result.previousYear).toBe(2025);
+    expect(result.currentYearTotal).toBe(0);
+    expect(result.previousYearTotal).toBe(0);
+    expect(result.percentageChange).toBeNull();
+  });
+
+  it("places a single Jan 2026 activity in the correct month for distance metric", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-01-20T08:00:00Z",
+        distance: 30000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.data[0].month).toBe("Jan");
+    expect(result.data[0].current).toBe(30);
+    for (let i = 1; i < 12; i++) {
+      expect(result.data[i].current).toBe(0);
+    }
+  });
+
+  it("aggregates activities from both current and previous year", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-01-10T08:00:00Z",
+        distance: 30000,
+      }),
+      makeActivity({
+        start_date_local: "2025-01-10T08:00:00Z",
+        distance: 20000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.data[0].current).toBe(30);
+    expect(result.data[0].previous).toBe(20);
+  });
+
+  it("converts distance from meters to kilometers", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-02-05T10:00:00Z",
+        distance: 25000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.data[1].current).toBe(25);
+  });
+
+  it("uses raw meters for elevation without rounding", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-01-15T10:00:00Z",
+        total_elevation_gain: 200.7,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "elevation", NOW);
+
+    expect(result.data[0].current).toBe(200.7);
+  });
+
+  it("counts activities per month for rides metric", () => {
+    const activities = [
+      makeActivity({
+        id: 1,
+        start_date_local: "2026-02-01T10:00:00Z",
+      }),
+      makeActivity({
+        id: 2,
+        start_date_local: "2026-02-10T10:00:00Z",
+      }),
+      makeActivity({
+        id: 3,
+        start_date_local: "2026-02-20T10:00:00Z",
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "rides", NOW);
+
+    expect(result.data[1].current).toBe(3);
+  });
+
+  it("converts moving_time from seconds to hours for time metric", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-01-15T10:00:00Z",
+        moving_time: 7200,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "time", NOW);
+
+    expect(result.data[0].current).toBe(2);
+  });
+
+  it("ignores activities outside the 2-year window", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2024-06-15T10:00:00Z",
+        distance: 50000,
+      }),
+      makeActivity({
+        start_date_local: "2023-01-15T10:00:00Z",
+        distance: 40000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.data.every((d) => d.current === 0 && d.previous === 0)).toBe(
+      true
+    );
+  });
+
+  it("sums multiple activities in the same month", () => {
+    const activities = [
+      makeActivity({
+        id: 1,
+        start_date_local: "2026-02-05T10:00:00Z",
+        distance: 10000,
+      }),
+      makeActivity({
+        id: 2,
+        start_date_local: "2026-02-20T10:00:00Z",
+        distance: 15000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.data[1].current).toBe(25);
+  });
+
+  it("calculates YTD totals using only months up to the current month", () => {
+    const activities = [
+      makeActivity({
+        id: 1,
+        start_date_local: "2026-01-10T10:00:00Z",
+        distance: 10000,
+      }),
+      makeActivity({
+        id: 2,
+        start_date_local: "2026-02-10T10:00:00Z",
+        distance: 20000,
+      }),
+      makeActivity({
+        id: 3,
+        start_date_local: "2026-03-10T10:00:00Z",
+        distance: 30000,
+      }),
+      makeActivity({
+        id: 4,
+        start_date_local: "2026-06-10T10:00:00Z",
+        distance: 50000,
+      }),
+    ];
+    // now is March 15, so YTD = Jan + Feb + Mar only
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.currentYearTotal).toBe(60); // 10+20+30 km
+  });
+
+  it("returns null percentageChange when previous year total is zero", () => {
+    const activities = [
+      makeActivity({
+        start_date_local: "2026-01-10T10:00:00Z",
+        distance: 50000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.previousYearTotal).toBe(0);
+    expect(result.percentageChange).toBeNull();
+  });
+
+  it("calculates positive percentage change correctly", () => {
+    const activities = [
+      // Current year: 150km total in Jan-Mar
+      makeActivity({
+        id: 1,
+        start_date_local: "2026-01-10T10:00:00Z",
+        distance: 50000,
+      }),
+      makeActivity({
+        id: 2,
+        start_date_local: "2026-02-10T10:00:00Z",
+        distance: 50000,
+      }),
+      makeActivity({
+        id: 3,
+        start_date_local: "2026-03-10T10:00:00Z",
+        distance: 50000,
+      }),
+      // Previous year: 100km total in Jan-Mar
+      makeActivity({
+        id: 4,
+        start_date_local: "2025-01-10T10:00:00Z",
+        distance: 50000,
+      }),
+      makeActivity({
+        id: 5,
+        start_date_local: "2025-02-10T10:00:00Z",
+        distance: 50000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.currentYearTotal).toBe(150);
+    expect(result.previousYearTotal).toBe(100);
+    expect(result.percentageChange).toBeCloseTo(50);
+    expect(result.difference).toBe(50);
+  });
+
+  it("calculates negative percentage change correctly", () => {
+    const activities = [
+      // Current year: 80km in Jan-Mar
+      makeActivity({
+        id: 1,
+        start_date_local: "2026-01-10T10:00:00Z",
+        distance: 40000,
+      }),
+      makeActivity({
+        id: 2,
+        start_date_local: "2026-02-10T10:00:00Z",
+        distance: 40000,
+      }),
+      // Previous year: 100km in Jan-Mar
+      makeActivity({
+        id: 3,
+        start_date_local: "2025-01-10T10:00:00Z",
+        distance: 50000,
+      }),
+      makeActivity({
+        id: 4,
+        start_date_local: "2025-02-10T10:00:00Z",
+        distance: 50000,
+      }),
+    ];
+    const result = aggregateByYearMonth(activities, "distance", NOW);
+
+    expect(result.currentYearTotal).toBe(80);
+    expect(result.previousYearTotal).toBe(100);
+    expect(result.percentageChange).toBeCloseTo(-20);
+    expect(result.difference).toBe(-20);
+  });
+});
+
+describe("formatMetricValue", () => {
+  it("formats distance with one decimal and km suffix", () => {
+    expect(formatMetricValue(150.5, "distance")).toBe("150.5 km");
+  });
+
+  it("formats elevation with thousands separator and m suffix", () => {
+    expect(formatMetricValue(1234, "elevation")).toBe("1,234 m");
+  });
+
+  it("formats rides count with plural suffix", () => {
+    expect(formatMetricValue(15, "rides")).toBe("15 rides");
+  });
+
+  it("formats time with one decimal and hrs suffix", () => {
+    expect(formatMetricValue(12.5, "time")).toBe("12.5 hrs");
+  });
+});
+
+describe("formatSummaryText", () => {
+  it("returns positive diff text for distance", () => {
+    const result = aggregateByYearMonth(
+      [
+        // Current: ~190km more than previous
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+          distance: 350000,
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2025-01-10T10:00:00Z",
+          distance: 160000,
+        }),
+      ],
+      "distance",
+      NOW
+    );
+    const summary = formatSummaryText(result, "distance");
+
+    expect(summary.text).toBe("You've ridden ");
+    expect(summary.highlight).toContain("more");
+    expect(summary.highlight).toContain("km");
+    expect(summary.highlight).toContain("+");
+    expect(summary.highlight).toContain("%");
+    expect(summary.suffix).toBe(" than this time last year");
+  });
+
+  it("returns negative diff text for distance", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+          distance: 50000,
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2025-01-10T10:00:00Z",
+          distance: 100000,
+        }),
+      ],
+      "distance",
+      NOW
+    );
+    const summary = formatSummaryText(result, "distance");
+
+    expect(summary.highlight).toContain("less");
+    expect(summary.highlight).toContain("-");
+    expect(summary.highlight).toContain("%");
+  });
+
+  it("returns zero diff text for distance", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+          distance: 50000,
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2025-01-10T10:00:00Z",
+          distance: 50000,
+        }),
+      ],
+      "distance",
+      NOW
+    );
+    const summary = formatSummaryText(result, "distance");
+
+    expect(summary.highlight).toContain("the same distance as");
+    expect(summary.suffix).toBe(" this time last year");
+  });
+
+  it("returns zero diff text for elevation", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+          total_elevation_gain: 500,
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2025-01-10T10:00:00Z",
+          total_elevation_gain: 500,
+        }),
+      ],
+      "elevation",
+      NOW
+    );
+    const summary = formatSummaryText(result, "elevation");
+
+    expect(summary.highlight).toContain("the same elevation as");
+  });
+
+  it("returns zero diff text for time", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+          moving_time: 3600,
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2025-01-10T10:00:00Z",
+          moving_time: 3600,
+        }),
+      ],
+      "time",
+      NOW
+    );
+    const summary = formatSummaryText(result, "time");
+
+    expect(summary.highlight).toContain("the same time as");
+  });
+
+  it("uses ride-specific wording for rides metric", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          id: 1,
+          start_date_local: "2026-01-10T10:00:00Z",
+        }),
+        makeActivity({
+          id: 2,
+          start_date_local: "2026-02-10T10:00:00Z",
+        }),
+        makeActivity({
+          id: 3,
+          start_date_local: "2025-01-10T10:00:00Z",
+        }),
+      ],
+      "rides",
+      NOW
+    );
+    const summary = formatSummaryText(result, "rides");
+
+    expect(summary.text).toBe("You've completed ");
+    expect(summary.highlight).toContain("more");
+    expect(summary.highlight).toContain("ride");
+    expect(summary.suffix).toBe(" than this time last year");
+  });
+
+  it("omits percentage when percentageChange is null", () => {
+    const result = aggregateByYearMonth(
+      [
+        makeActivity({
+          start_date_local: "2026-01-10T10:00:00Z",
+          distance: 50000,
+        }),
+      ],
+      "distance",
+      NOW
+    );
+    const summary = formatSummaryText(result, "distance");
+
+    expect(summary.highlight).not.toContain("%");
+  });
+});

--- a/src/lib/year-comparison.ts
+++ b/src/lib/year-comparison.ts
@@ -1,0 +1,205 @@
+import { type StravaActivity } from "@/lib/strava";
+
+export type YearComparisonMetric = "distance" | "elevation" | "rides" | "time";
+
+export interface MonthlyData {
+  month: string;
+  monthIndex: number;
+  current: number;
+  previous: number;
+}
+
+export interface YearComparisonResult {
+  data: MonthlyData[];
+  currentYear: number;
+  previousYear: number;
+  currentYearTotal: number;
+  previousYearTotal: number;
+  difference: number;
+  percentageChange: number | null;
+}
+
+export interface SummaryText {
+  text: string;
+  highlight: string;
+  suffix: string;
+}
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/** Extract the numeric value for a given metric from an activity. */
+function extractMetricValue(
+  activity: StravaActivity,
+  metric: YearComparisonMetric
+): number {
+  switch (metric) {
+    case "distance":
+      return activity.distance / 1000;
+    case "elevation":
+      return activity.total_elevation_gain;
+    case "rides":
+      return 1;
+    case "time":
+      return activity.moving_time / 3600;
+  }
+}
+
+/**
+ * Aggregates Strava activities into month-by-month data for the current year
+ * and the previous year, computing YTD totals and percentage change.
+ *
+ * @param activities - Array of Strava activities to aggregate
+ * @param metric - Which metric to aggregate (distance, elevation, rides, time)
+ * @param now - Reference date for determining current/previous year (defaults to today)
+ */
+export function aggregateByYearMonth(
+  activities: StravaActivity[],
+  metric: YearComparisonMetric,
+  now: Date = new Date()
+): YearComparisonResult {
+  const currentYear = now.getFullYear();
+  const previousYear = currentYear - 1;
+  const currentMonth = now.getMonth();
+
+  // Initialize 12-month grid with zeroes
+  const data: MonthlyData[] = MONTH_NAMES.map((month, index) => ({
+    month,
+    monthIndex: index,
+    current: 0,
+    previous: 0,
+  }));
+
+  // Bucket each activity into the appropriate month slot
+  for (const activity of activities) {
+    const date = new Date(activity.start_date_local);
+    const year = date.getFullYear();
+    const month = date.getMonth();
+
+    if (year === currentYear) {
+      data[month].current += extractMetricValue(activity, metric);
+    } else if (year === previousYear) {
+      data[month].previous += extractMetricValue(activity, metric);
+    }
+    // Activities outside the 2-year window are silently ignored
+  }
+
+  // YTD totals: only sum months 0 through the current month (inclusive)
+  let currentYearTotal = 0;
+  let previousYearTotal = 0;
+  for (let i = 0; i <= currentMonth; i++) {
+    currentYearTotal += data[i].current;
+    previousYearTotal += data[i].previous;
+  }
+
+  const difference = currentYearTotal - previousYearTotal;
+  const percentageChange =
+    previousYearTotal === 0
+      ? null
+      : ((currentYearTotal - previousYearTotal) / previousYearTotal) * 100;
+
+  return {
+    data,
+    currentYear,
+    previousYear,
+    currentYearTotal,
+    previousYearTotal,
+    difference,
+    percentageChange,
+  };
+}
+
+/**
+ * Formats a numeric metric value into a human-readable string with the
+ * appropriate unit suffix.
+ */
+export function formatMetricValue(
+  value: number,
+  metric: YearComparisonMetric
+): string {
+  switch (metric) {
+    case "distance":
+      return `${value.toFixed(1)} km`;
+    case "elevation":
+      return `${Math.round(value).toLocaleString("en-US")} m`;
+    case "rides":
+      return `${value} ${value === 1 ? "ride" : "rides"}`;
+    case "time":
+      return `${value.toFixed(1)} hrs`;
+  }
+}
+
+/** Map from metric to its unit label used in summary text. */
+const METRIC_UNITS: Record<YearComparisonMetric, string> = {
+  distance: "km",
+  elevation: "m",
+  rides: "rides",
+  time: "hrs",
+};
+
+/**
+ * Builds a structured summary sentence describing the year-over-year change.
+ * Returns separate text/highlight/suffix fields so callers can style the
+ * highlight portion differently (e.g., bold, colored).
+ */
+export function formatSummaryText(
+  result: YearComparisonResult,
+  metric: YearComparisonMetric
+): SummaryText {
+  const { difference, percentageChange } = result;
+  const absDiff = Math.abs(difference);
+
+  const isRides = metric === "rides";
+  const verb = isRides ? "You've completed " : "You've ridden ";
+
+  // Zero difference — special case
+  if (difference === 0) {
+    const ZERO_DIFF_NOUN: Record<YearComparisonMetric, string> = {
+      distance: "the same distance as",
+      elevation: "the same elevation as",
+      rides: "the same number of rides as",
+      time: "the same time as",
+    };
+    return {
+      text: verb,
+      highlight: ZERO_DIFF_NOUN[metric],
+      suffix: " this time last year",
+    };
+  }
+
+  const formattedDiff = absDiff.toLocaleString("en-US");
+  const unit = METRIC_UNITS[metric];
+  const pctPart =
+    percentageChange !== null
+      ? ` (${difference > 0 ? "+" : ""}${Math.round(percentageChange)}%)`
+      : "";
+
+  if (isRides) {
+    const direction = difference > 0 ? "more" : "fewer";
+    const rideWord = absDiff === 1 ? "ride" : "rides";
+    return {
+      text: verb,
+      highlight: `${formattedDiff} ${direction} ${rideWord}${pctPart}`,
+      suffix: " than this time last year",
+    };
+  }
+
+  const direction = difference > 0 ? "more" : "less";
+  return {
+    text: verb,
+    highlight: `${formattedDiff} ${unit} ${direction}${pctPart}`,
+    suffix: " than this time last year",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a year-over-year monthly comparison chart to the dashboard (after Personal Records, full-width)
- Pure data aggregation module (`src/lib/year-comparison.ts`) with 24 unit tests covering all metrics, edge cases, and summary text
- Recharts grouped bar component with metric toggle pills (Distance, Elevation, Rides, Time), custom legend, and dynamic summary text
- Updates CLAUDE.md project structure docs

## Details
- Two-layer architecture: testable data logic separated from rendering
- Follows existing chart patterns (card wrapper, tooltip styling, axis config, `as never` cast)
- Metric toggle: Strava orange active pill, grouped bars for current vs previous year
- Summary text adapts per metric (e.g., "You've ridden **190 km more (+34%)** than this time last year")
- YTD totals only count through the current month; `percentageChange` returns `null` when previous year is zero

Closes #15

## Test plan
- [x] `npm run test` — 41 tests pass (24 new)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — successful
- [ ] Visual: `npm run dev` → verify chart renders after PersonalRecords, metric toggles work, dark/light mode correct
- [ ] CI: GitHub Actions passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)